### PR TITLE
fix: order associated items chronologically in application view

### DIFF
--- a/src/modules/booking/inc/class.uiapplication.inc.php
+++ b/src/modules/booking/inc/class.uiapplication.inc.php
@@ -821,6 +821,10 @@ class booking_uiapplication extends booking_uicommon
 			$case_officer = true;
 		}
 
+		// Get sort parameters from request
+		$sort = Sanitizer::get_var('sort', 'string');
+		$dir = Sanitizer::get_var('dir', 'string');
+
 		// Get associations from all related applications for combined display only if combining is enabled
 		if ($this->combine_applications)
 		{
@@ -840,14 +844,29 @@ class booking_uiapplication extends booking_uicommon
 					$all_associations = array_merge($all_associations, $app_associations['results']);
 				}
 			}
+
+			// Sort the combined associations if sort parameter is provided
+			if ($sort && !empty($all_associations))
+			{
+				$sort_order = (strtolower($dir) === 'desc') ? SORT_DESC : SORT_ASC;
+
+				// Extract the column to sort by
+				$sort_column = array_column($all_associations, $sort);
+
+				// Sort the associations
+				array_multisort($sort_column, $sort_order, SORT_REGULAR, $all_associations);
+			}
+
 			$associations = array('results' => $all_associations);
 		}
 		else
 		{
-			// Single application - use existing logic
+			// Single application - pass sort parameters to read method
 			$associations = $this->assoc_bo->so->read(array(
 				'filters' => array('application_id' => $application_id),
-				'results' => 'all'
+				'results' => 'all',
+				'sort' => $sort,
+				'dir' => $dir
 			));
 		}
 		foreach ($associations['results'] as &$association)


### PR DESCRIPTION
Add sort parameter handling to associated() method to respect frontend sorting request. Associations now ordered by from_ field in ascending order as expected.

ref #722