### PR TITLE
Add owner and modification tracking to resource activity entity forms

### DIFF
--- a/src/modules/booking/inc/class.soresource_activity_entityform.inc.php
+++ b/src/modules/booking/inc/class.soresource_activity_entityform.inc.php
@@ -1,6 +1,8 @@
 <?php
 phpgw::import_class('booking.socommon');
 
+use App\modules\phpgwapi\controllers\Locations;
+use App\modules\phpgwapi\services\CustomFields;
 
 /**
  * resource_activity_entityform is used for managing the entity forms for resource activities.
@@ -33,6 +35,9 @@ class booking_soresource_activity_entityform extends booking_socommon
 				'resources' => array('type' => 'json', 'required' => true),
 				'activities' => array('type' => 'json', 'required' => true),
 				'location_id' => array('type' => 'int', 'required' => true),
+				'owner_id' => array('type' => 'int', 'required' => true),
+				'modified_on' => array('type' => 'timestamp', 'required' => true),
+				'modified_by' => array('type' => 'int', 'required' => true),
 			)
 		);
 		$this->account = $this->userSettings['account_id'];
@@ -40,6 +45,8 @@ class booking_soresource_activity_entityform extends booking_socommon
 
 	protected function preValidate(&$entity)
 	{
+		$entity['modified_by'] = $this->account;
+		$entity['modified_on'] = date('Y-m-d H:i:s');
 	}
 
 	/**
@@ -105,14 +112,19 @@ class booking_soresource_activity_entityform extends booking_socommon
 	 * @param int $resource_id The ID of the resource to search for
 	 * @param int $activity_id The ID of the activity to search for
 	 *
-	 * @return int|null The location_id of the matching entity form, or null if no matching entity form is found
+	 * @return array An associative array containing the following keys:
+	 * 			 - 'has_dynamic_form' (bool): Indicates whether a matching entity form was found
+	 * 			 - 'location_id' (int|null): The location_id of the matching entity form, or null if no matching entity form is found
+	 * 			 - 'owner_id' (int|null): The owner_id of the matching entity form, or null if no matching entity form is found
+	 * 			 - 'attributes' (array): The attributes of the matching entity form, or an empty array if no matching entity form is found
+	 * 			 - 'groups' (array): The groups of the matching entity form, or an empty array if no matching entity form is found
 	 *
 	 * @note This method assumes that there should be at most one active entity form for a given combination
 	 *       of resource and activity, as enforced by the validation in doValidate().
 	 */
 	public function get_entity_form_by_resource_and_activity($resource_id, $activity_id)
 	{
-		$sql = "SELECT location_id FROM public.bb_resource_activity_entityform "
+		$sql = "SELECT location_id, owner_id FROM public.bb_resource_activity_entityform "
 			. "WHERE active = 1 "
 			. "AND resources @> :resource_json::jsonb "
 			. "AND activities @> :activity_json::jsonb "
@@ -124,7 +136,57 @@ class booking_soresource_activity_entityform extends booking_socommon
 			':activity_json' => json_encode(array((string)$activity_id)),
 		));
 
-		$location_id = $stmt->fetchColumn();
-		return $location_id !== false ? $location_id : null;
+		$result = $stmt->fetch(PDO::FETCH_ASSOC);
+
+		if ($result !== false) {
+
+			$attribute_data = $this->get_attribute_data($result['location_id']);
+			return array(
+				'has_dynamic_form' => true,
+				'location_id' => $result['location_id'],
+				'owner_id' => $result['owner_id'],
+				'attributes' => $attribute_data['attributes'],
+				'groups' => $attribute_data['groups'],
+			);
+		}
+
+		return array(
+			'has_dynamic_form' => false,
+			'location_id' => null,
+			'owner_id' => null,
+			'attributes' => array(),
+			'groups' => array(),
+		);
+	}
+
+
+	/**
+	 * Get attributes for a given location_id. This is used to display the attributes in the show view of the entity form, and also to validate the attributes when saving the entity form.
+	 * @param int $location_id
+	 * @return array
+	 */
+	public function get_attribute_data($location_id)
+	{
+		$CustomFields = new CustomFields('property');
+		$attrib_data = $CustomFields->find2(
+			$location_id,
+			$start = 0,
+			$query = '',
+			$sort = 'ASC',
+			$order = 'attrib_sort',
+			$allrows = true,
+			$inc_choices = true,
+			$filter = array(),
+			$results = 0
+		);
+
+		$location_obj = new Locations();
+		$location = $location_obj->get_location($location_id);
+		$group_data = $CustomFields->find_group('property', $location, 0, '', '', '', true);
+
+		return array(
+			'attributes' => $attrib_data,
+			'groups' => $group_data
+		);
 	}
 }

--- a/src/modules/booking/inc/class.uiresource_activity_entityform.inc.php
+++ b/src/modules/booking/inc/class.uiresource_activity_entityform.inc.php
@@ -5,6 +5,8 @@ use App\modules\phpgwapi\controllers\Locations;
 use App\modules\phpgwapi\services\Cache;
 use App\modules\phpgwapi\security\Acl;
 use App\modules\phpgwapi\services\CustomFields;
+use App\modules\phpgwapi\controllers\Accounts\Accounts;
+
 
 phpgw::import_class('booking.uicommon');
 
@@ -23,7 +25,7 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 
 	);
 
-	var $bo, $display_name, $activity_bo, $resource_bo, $building_bo, $boadmin_entity;
+	var $bo, $display_name, $activity_bo, $resource_bo, $building_bo, $boadmin_entity, $accounts_obj;
 
 
 
@@ -43,6 +45,7 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 		$this->resource_bo = CreateObject('booking.boresource');
 		$this->building_bo		 = CreateObject('booking.bobuilding');
 		$this->boadmin_entity			 = CreateObject('property.boadmin_entity');
+		$this->accounts_obj = new Accounts();
 
 		$this->display_name = lang('resource_activity_entityform');
 
@@ -60,7 +63,7 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 		$lang_yes = lang('yes');
 		$lang_no = lang('no');
 		$location_obj = new Locations();
-		
+
 
 		array_walk($entityforms["results"], array($this, "_add_links"), "booking.uiresource_activity_entityform.show");
 		foreach ($entityforms["results"] as &$entityform)
@@ -239,7 +242,7 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 		);
 		if ($_SERVER['REQUEST_METHOD'] == 'POST')
 		{
-			$_values = extract_values($_POST, array('name', 'active', 'activities', 'building_id', 'resources', 'location_id'));
+			$_values = extract_values($_POST, array('name', 'active', 'activities', 'building_id', 'resources', 'location_id', 'owner_id'));
 			$entityform = array_merge($entityform, $_values);
 			$entityform['active'] = !empty($_values['active']) ? 1 : 0;
 			$errors = $this->bo->validate($entityform);
@@ -274,7 +277,7 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 		$errors = array();
 		if ($_SERVER['REQUEST_METHOD'] == 'POST')
 		{
-			$_values = extract_values($_POST, array('name', 'active', 'activities', 'building_id', 'resources', 'location_id'));
+			$_values = extract_values($_POST, array('name', 'active', 'activities', 'building_id', 'resources', 'location_id', 'owner_id'));
 			$entityform = array_merge($entityform, $_values);
 			$entityform['active'] = !empty($_values['active']) ? 1 : 0;
 			$errors = $this->bo->validate($entityform);
@@ -309,7 +312,7 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 			phpgw::no_access('booking', lang('missing entry. Id %1 is invalid', $id));
 		}
 
-		if($this->bo->delete($id))
+		if ($this->bo->delete($id))
 		{
 			$status['deleted'] = true;
 		}
@@ -332,6 +335,12 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 		{
 			phpgw::no_access('booking', lang('missing entry. Id %1 is invalid', $id));
 		}
+
+		$owner = $this->accounts_obj->get($entityform['owner_id']);
+		$owner_name = $owner->__toString();
+		$owner_lid = $owner->lid;
+	
+		$entityform['owner_name'] = "$owner_name ($owner_lid)";
 
 		$activities = $this->activity_bo->fetch_activities();
 		$activities = $activities['results'];
@@ -470,8 +479,24 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 			Cache::message_set(implode("<br/>", (array)$error), 'error');
 		}
 
-		$tabs = array();
+		if (!empty($entityform['owner_id']))
+		{
+			$owner = $this->accounts_obj->get($entityform['owner_id']);
+			$owner_name = $owner->__toString();
+			$owner_lid = $owner->lid;
+			$owners = array(
+				'options' => array(
+					'id' => $entityform['owner_id'] ?? 0,
+					'name' => "$owner_name ($owner_lid)"
+				)
+			);
+		}
+		else
+		{
+			$owners = array('options' => array());
+		}
 
+		$tabs = array();
 		$tab_label = empty($entityform['id']) ? lang('Add') : lang('Edit');
 		$tabs['generic'] = array('label' => $tab_label, 'link' => '#entityform_new');
 		$active_tab = 'generic';
@@ -520,17 +545,12 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 		$data = array(
 			'tabs' => phpgwapi_jquery::tabview_generate($tabs, $active_tab),
 			'entityform' => $entityform,
+			'owners' => $owners,
 			'activities' => array('options' => $activities),
 			'entities' => array('options' => $entities),
 			'categories' => array('options' => $categories),
 			'resources_json' => json_encode($entityform['resources']),
 			'cancel_link' => self::link(array('menuaction' => 'booking.uiresource_activity_entityform.index')),
-			'validator' => phpgwapi_jquery::formvalidator_generate(array(
-				'location',
-				'date',
-				'security',
-				'file'
-			))
 		);
 
 		phpgwapi_jquery::load_widget('select2');
@@ -541,7 +561,7 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 		));
 	}
 
-	
+
 	public function get_categories()
 	{
 		$entity_id = Sanitizer::get_var('entity_id', 'int');
@@ -561,26 +581,6 @@ class booking_uiresource_activity_entityform extends booking_uicommon
 	 */
 	public function get_attributes($location_id)
 	{
-		$CustomFields = new CustomFields('property');
-		$attrib_data = $CustomFields->find2(
-			$location_id,
-			$start = 0,
-			$query = '',
-			$sort = 'ASC',
-			$order = 'attrib_sort',
-			$allrows = true,
-			$inc_choices = true,
-			$filter = array(),
-			$results = 0
-		);
-
-		$location_obj = new Locations();
-		$location = $location_obj->get_location($location_id);
-		$group_data = $CustomFields->find_group('property', $location, 0, '', '', '', true);
-
-		return array(
-			'attributes' => $attrib_data,
-			'groups' => $group_data
-		);
+		return $this->bo->get_attribute_data($location_id);
 	}
 }

--- a/src/modules/booking/js/base/resource_activity_entityform.js
+++ b/src/modules/booking/js/base/resource_activity_entityform.js
@@ -3,6 +3,158 @@
 var building_id_selection = "";
 $(document).ready(function ()
 {
+	var $form = $('#form');
+	var validationSubmitted = false;
+	var errorColor = '#d9534f';
+	var okColor = '#28a745';
+
+	$form.attr('novalidate', 'novalidate');
+
+	function getValidationMessage($field, fallbackMessage)
+	{
+		return $field.attr('data-validation-error-msg') || fallbackMessage;
+	}
+
+	function getValidationFeedbackElement($field)
+	{
+		var $feedback = $field.data('validationFeedback');
+
+		if (!$feedback || !$feedback.length)
+		{
+			$feedback = $('<div class="validation-status"></div>');
+			if ($field.hasClass('select2-hidden-accessible'))
+			{
+				$field.next('.select2').after($feedback);
+			}
+			else
+			{
+				$field.after($feedback);
+			}
+			$field.data('validationFeedback', $feedback);
+		}
+
+		return $feedback;
+	}
+
+	function updateFieldState($field, isValid, message)
+	{
+		var $target = $field;
+		var $feedback = getValidationFeedbackElement($field);
+
+		if ($field.hasClass('select2-hidden-accessible'))
+		{
+			$target = $field.next('.select2').find('.select2-selection');
+		}
+
+		$field.toggleClass('error', !isValid).toggleClass('ok', isValid);
+		$target.toggleClass('error', !isValid).toggleClass('ok', isValid).css('border-color', isValid ? okColor : errorColor);
+		$feedback.text(isValid ? 'ok' : message).css({
+			color: isValid ? okColor : errorColor,
+			marginTop: '0.25rem',
+			display: 'block'
+		});
+	}
+
+	function validateRequiredField($field)
+	{
+		var value = $field.val();
+		var isValid;
+
+		if ($field.is('select[multiple]'))
+		{
+			isValid = Array.isArray(value) ? value.length > 0 : !!value;
+		}
+		else
+		{
+			isValid = !!String(value || '').trim();
+		}
+
+		updateFieldState($field, isValid, getValidationMessage($field, 'This field is required'));
+		return isValid;
+	}
+
+	function updateResourcesState(isValid)
+	{
+		var $container = $('#resources_container');
+		var $table = $container.find('table');
+		var $indicator = $container.find('.validation-status');
+		var message = getValidationMessage(
+			$('input[data-validation="application_resources"]'),
+			'Please choose at least 1 resource'
+		);
+
+		if (!$indicator.length)
+		{
+			$indicator = $('<div class="validation-status"></div>');
+			$container.append($indicator);
+		}
+
+		$table.toggleClass('error', !isValid).toggleClass('ok', isValid).css('border-color', isValid ? okColor : errorColor);
+		$indicator.text(isValid ? 'ok' : message).css({
+			color: isValid ? okColor : errorColor,
+			marginTop: '0.25rem',
+			display: 'block'
+		});
+	}
+
+	function validateResourcesSelection()
+	{
+		var isValid = $('#resources_container input[name="resources[]"]:checked').length > 0;
+		updateResourcesState(isValid);
+		return isValid;
+	}
+
+	function validateForm()
+	{
+		var isValid = true;
+
+		$form.find('[required]').each(function ()
+		{
+			if (!validateRequiredField($(this)))
+			{
+				isValid = false;
+			}
+		});
+
+		if (!validateResourcesSelection())
+		{
+			isValid = false;
+		}
+
+		return isValid;
+	}
+
+	$form.on('submit', function (event)
+	{
+		var $firstInvalid;
+		validationSubmitted = true;
+
+		if (!validateForm())
+		{
+			event.preventDefault();
+			$firstInvalid = $form.find('[required].error').first();
+			if ($firstInvalid.length)
+			{
+				if ($firstInvalid.hasClass('select2-hidden-accessible'))
+				{
+					$firstInvalid.select2('open');
+				}
+				else
+				{
+					$firstInvalid.trigger('focus');
+				}
+			}
+			return false;
+		}
+	});
+
+	$form.find('[required]').on('input change', function ()
+	{
+		if (validationSubmitted)
+		{
+			validateRequiredField($(this));
+		}
+	});
 
 	JqueryPortico.autocompleteHelper(phpGWLink('index.php', {menuaction: 'booking.uibuilding.index'}, true),
 		'field_building_name', 'field_building_id', 'building_container');
@@ -12,16 +164,51 @@ $(document).ready(function ()
 			width: '100%'
 		});
 
-		$('#field_activities').on('select2:open', function (e) {
+	$('#field_activities').on('select2:open', function (e) {
 
-			$(".select2-search__field").each(function()
+		$(".select2-search__field").each(function()
+		{
+			if ($(this).attr("aria-controls") == 'select2-field_activities-results')
 			{
-				if ($(this).attr("aria-controls") == 'select2-field_activities-results')
-				{
-					$(this)[0].focus();
-				}
-			});
-		});		
+				$(this)[0].focus();
+			}
+		});
+	});
+
+	var oArgs = {menuaction: 'preferences.boadmin_acl.get_users'};
+	var strURL = phpGWLink('index.php', oArgs, true);
+
+	$("#field_owner_id").select2({
+		ajax: {
+		url: strURL,
+		dataType: 'json',
+		delay: 250,
+		data: function (params) {
+			return {
+			query: params.term, // search term
+			page: params.page || 1
+			};
+		},
+		cache: true
+		},
+		width: '100%',
+		placeholder: lang['Owner'],
+		minimumInputLength: 2,
+		language: "no",
+		allowClear: true
+	});
+
+	$('#field_owner_id').on('select2:open', function (e) {
+
+		$(".select2-search__field").each(function()
+		{
+			if ($(this).attr("aria-controls") == 'select2-field_owner_id-results')
+			{
+				$(this)[0].focus();
+			}
+		});
+	});
+
 	
 	//on change of the select field_entities, look up category and set field_category options accordingly
 	$("#field_entities").on("change", function (event)
@@ -69,49 +256,21 @@ $(window).on('load', function ()
 
 	$('#resources_container').on('change', '.chkRegulations', function ()
 	{
-		var resources = new Array();
+		var resources = [];
 		$('#resources_container input[name="resources[]"]:checked').each(function ()
 		{
 			resources.push($(this).val());
 		});
 
+		if (validationSubmitted)
+		{
+			validateResourcesSelection();
+		}
 	});
 
 
 });
 
-if ($.formUtils)
-{
-
-	$.formUtils.addValidator({
-		name: 'application_resources',
-		validatorFunction: function (value, $el, config, language, $form)
-		{
-			var n = 0;
-			$('#resources_container table input[name="resources[]"]').each(function ()
-			{
-				if ($(this).is(':checked'))
-				{
-					n++;
-				}
-			});
-			var v = (n > 0) ? true : false;
-
-			if(!v)
-			{
-				$('#resources_container').find('table').addClass("error").css("border-color", "red");
-			}
-			else
-			{
-				$('#resources_container').find('table').removeClass("error").css("border-color", "");
-			}
-
-			return v;
-		},
-		errorMessage: 'Please choose at least 1 resource',
-		errorMessageKey: 'application_resources'
-	});
-}
 
 function populateTableChkResources(building_id, selection)
 {

--- a/src/modules/booking/setup/phpgw_en.lang
+++ b/src/modules/booking/setup/phpgw_en.lang
@@ -696,6 +696,7 @@ override	booking	en	Override
 override dim	booking	en	Override Dimension
 override_price	booking	en	Override price
 overwrite_with_mine	booking	en	Overwrite with mine
+Owner	booking	en	Owner
 owner_id	booking	en	Owner_id
 parent activity	booking	en	Parent activity
 parent group	booking	en	Parent group

--- a/src/modules/booking/setup/phpgw_nn.lang
+++ b/src/modules/booking/setup/phpgw_nn.lang
@@ -769,6 +769,7 @@ override	booking	nn	Overstyring
 override dim	booking	nn	Overstyr Dimensjon
 override_price	booking	nn	Overstyrpris
 overwrite_with_mine	booking	nn	Overskriv med mine
+Owner	booking	nn	Eigar
 owner_id	booking	nn	Eigar
 parent activity	booking	nn	Overordna kategori
 parent group	booking	nn	Overordna gruppe

--- a/src/modules/booking/setup/phpgw_no.lang
+++ b/src/modules/booking/setup/phpgw_no.lang
@@ -758,6 +758,7 @@ override	booking	no	Overstyring
 override dim	booking	no	Overstyr Dimensjon
 override_price	booking	no	Overstyrpris
 overwrite_with_mine	booking	no	Overskriv med mine
+Owner	booking	no	Eier
 owner_id	booking	no	Eier
 parent activity	booking	no	Overordnet kategori
 parent group	booking	no	Overordnet gruppe

--- a/src/modules/booking/setup/setup.inc.php
+++ b/src/modules/booking/setup/setup.inc.php
@@ -1,6 +1,6 @@
 <?php
 $setup_info['booking']['name'] = 'booking';
-$setup_info['booking']['version'] = '0.2.127';
+$setup_info['booking']['version'] = '0.2.128';
 $setup_info['booking']['app_order'] = 9;
 $setup_info['booking']['enable'] = 1;
 $setup_info['booking']['app_group'] = 'office';

--- a/src/modules/booking/setup/tables_current.inc.php
+++ b/src/modules/booking/setup/tables_current.inc.php
@@ -350,11 +350,16 @@ $phpgw_baseline = array(
 			'resources' => array('type' => 'jsonb',  'nullable' => False),
 			'activities' => array('type' => 'jsonb',  'nullable' => True),
 			'location_id' => array('type' => 'int', 'precision' => 4, 'nullable' => False),
+			'owner_id' => array('type' => 'int', 'precision' => 4, 'nullable' => False), // system user that is the owner of the entityform, used for filter access permissions to specific group of case officers in the application process
+			'modified_on' => array('type' => 'timestamp', 'nullable' => False, 'default' => 'current_timestamp'),
+			'modified_by' => array('type' => 'int', 'precision' => '4', 'nullable' => False),
 		),
 		'pk' => array('id'),
 		'fk' => array(
 			'phpgw_locations' => array('location_id' => 'location_id'),
 			'bb_building' => array('building_id' => 'id'),
+			'phpgw_accounts' => array('owner_id' => 'account_id'),
+			'phpgw_accounts' => array('modified_by' => 'account_id'),
 		),
 		'ix' => array(),
 		'uc' => array(),

--- a/src/modules/booking/setup/tables_update.inc.php
+++ b/src/modules/booking/setup/tables_update.inc.php
@@ -8436,3 +8436,19 @@ function booking_upgrade0_2_126($oProc)
 		return $currentver;
 	}
 }
+
+$test[] = '0.2.127';
+function booking_upgrade0_2_127($oProc)
+{
+	$oProc->m_odb->transaction_begin();
+	$oProc->AddColumn('bb_resource_activity_entityform', 'owner_id', array('type' => 'int', 'precision' => 4, 'nullable' => false));
+	$oProc->AddColumn('bb_resource_activity_entityform', 'modified_on', array('type' => 'timestamp', 'nullable' => false, 'default' => 'current_timestamp'));
+	$oProc->AddColumn('bb_resource_activity_entityform', 'modified_by', array('type' => 'int', 'precision' => 4, 'nullable' => false));
+	$oProc->m_odb->query("ALTER TABLE bb_resource_activity_entityform ADD CONSTRAINT fk_entityform_owner FOREIGN KEY (owner_id) REFERENCES phpgw_accounts(account_id)");
+	$oProc->m_odb->query("ALTER TABLE bb_resource_activity_entityform ADD CONSTRAINT fk_entityform_modified_by FOREIGN KEY (modified_by) REFERENCES phpgw_accounts(account_id)");
+	if ($oProc->m_odb->transaction_commit())
+	{
+		$currentver = '0.2.128';
+		return $currentver;
+	}
+}	

--- a/src/modules/booking/templates/base/resource_activity_entityform.xsl
+++ b/src/modules/booking/templates/base/resource_activity_entityform.xsl
@@ -41,11 +41,33 @@
 						<xsl:value-of select="php:function('lang', 'Active')" />
 					</label>
 				</div>
+
+				<div class="pure-control-group">
+					<label>
+						<xsl:value-of select="php:function('lang', 'owner_id')" />
+					</label>
+
+					<select id="field_owner_id" name="owner_id" required="required" class="pure-u-1 pure-u-sm-1-2 pure-u-md-1">
+						<xsl:attribute name="data-validation">
+							<xsl:text>required</xsl:text>
+						</xsl:attribute>
+						<xsl:attribute name="data-validation-error-msg">
+							<xsl:value-of select="php:function('lang', 'Please enter a name')" />
+						</xsl:attribute>
+						<xsl:apply-templates select="owners/options" />
+					</select>
+				</div>
 				<div class="pure-control-group">
 					<label>
 						<xsl:value-of select="php:function('lang', 'Activities')" />
 					</label>
 					<select id="field_activities" name="activities[]" multiple="" required="required" class="pure-u-1 pure-u-sm-1-2 pure-u-md-1">
+						<xsl:attribute name="data-validation">
+							<xsl:text>required</xsl:text>
+						</xsl:attribute>
+						<xsl:attribute name="data-validation-error-msg">
+							<xsl:value-of select="php:function('lang', 'Please choose at least 1 activity')" />
+						</xsl:attribute>
 						<xsl:apply-templates select="activities/options" />
 					</select>
 				</div>
@@ -98,7 +120,7 @@
 						<span class="select_first_text">
 							<xsl:value-of select="php:function('lang', 'Select an entity type first')" />
 						</span>
-						<select id="field_category" name="location_id" class="pure-u-1 pure-u-sm-1-2 pure-u-md-1">
+						<select id="field_category" name="location_id" required="required" class="pure-u-1 pure-u-sm-1-2 pure-u-md-1">
 							<xsl:attribute name="data-validation">
 								<xsl:text>required</xsl:text>
 							</xsl:attribute>
@@ -126,7 +148,7 @@
 	<script type="text/javascript">
 		var template_set = '<xsl:value-of select="php:function('get_phpgw_info', 'user|preferences|common|template_set')" />';
 		var date_format = '<xsl:value-of select="php:function('get_phpgw_info', 'user|preferences|common|dateformat')" />';
-		var lang = 	<xsl:value-of select="php:function('js_lang', 'Name', 'From', 'To', 'Resource Type', 'Select', 'Selected', 'Delete', 'Activities')"/>;
+		var lang = 	<xsl:value-of select="php:function('js_lang', 'Name', 'From', 'To', 'Resource Type', 'Select', 'Selected', 'Delete', 'Activities', 'Owner')"/>;
 		var initialSelection =<xsl:value-of select="resources_json"/>;
 	</script>
 </xsl:template>
@@ -153,6 +175,10 @@
 								</xsl:otherwise>
 							</xsl:choose>
 						</td>
+					</tr>
+					<tr>
+						<th><xsl:value-of select="php:function('lang', 'Owner')" /></th>
+						<td><xsl:value-of select="entityform/owner_name" /></td>
 					</tr>
 					<tr>
 						<th><xsl:value-of select="php:function('lang', 'Building')" /></th>


### PR DESCRIPTION
- Introduced 'owner_id', 'modified_on', and 'modified_by' fields in the database schema and entity forms.
- Updated PHP classes to handle new fields and ensure proper validation.
- Enhanced JavaScript validation for required fields and resource selection.
- Added language support for 'Owner' in multiple language files.
- Updated XSL templates to include owner selection in the form.