### PR TITLE
Replace custom WS implementations with Socket.IO native features

### DIFF
--- a/src/WebSocket/node/src/adapters/redis-io.adapter.ts
+++ b/src/WebSocket/node/src/adapters/redis-io.adapter.ts
@@ -1,0 +1,30 @@
+import { IoAdapter } from '@nestjs/platform-socket.io';
+import { INestApplication, Logger } from '@nestjs/common';
+import { createAdapter } from '@socket.io/redis-adapter';
+import { ServerOptions } from 'socket.io';
+import Redis from 'ioredis';
+
+export class RedisIoAdapter extends IoAdapter {
+  private readonly logger = new Logger(RedisIoAdapter.name);
+  private adapterConstructor: ReturnType<typeof createAdapter> | null = null;
+
+  async connectToRedis(): Promise<void> {
+    const host = process.env.REDIS_HOST || 'portico_redis';
+    const port = parseInt(process.env.REDIS_PORT || '6379', 10);
+
+    const pubClient = new Redis({ host, port, lazyConnect: true });
+    const subClient = new Redis({ host, port, lazyConnect: true });
+
+    await Promise.all([pubClient.connect(), subClient.connect()]);
+    this.adapterConstructor = createAdapter(pubClient, subClient);
+    this.logger.log(`Redis adapter connected: ${host}:${port}`);
+  }
+
+  createIOServer(port: number, options?: ServerOptions) {
+    const server = super.createIOServer(port, options);
+    if (this.adapterConstructor) {
+      server.adapter(this.adapterConstructor);
+    }
+    return server;
+  }
+}

--- a/src/WebSocket/node/src/main.ts
+++ b/src/WebSocket/node/src/main.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { Logger } from '@nestjs/common';
+import { RedisIoAdapter } from './adapters/redis-io.adapter';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -12,6 +13,14 @@ async function bootstrap() {
       ? ['log', 'error', 'warn', 'debug', 'verbose']
       : ['log', 'error', 'warn'],
   });
+
+  try {
+    const redisAdapter = new RedisIoAdapter(app);
+    await redisAdapter.connectToRedis();
+    app.useWebSocketAdapter(redisAdapter);
+  } catch (err: any) {
+    logger.warn(`Redis adapter unavailable (rooms work locally only): ${err.message}`);
+  }
 
   await app.listen(port);
   logger.log(`WebSocket server listening on port ${port}`);

--- a/src/WebSocket/node/src/modules/gateway/portico.gateway.ts
+++ b/src/WebSocket/node/src/modules/gateway/portico.gateway.ts
@@ -20,10 +20,10 @@ import { PhpConfigService } from '../../config/php-config.service';
 
 @WebSocketGateway({
   cors: { origin: '*' },
-  // Serve on all paths — Apache proxies /wss to us
   namespace: '/',
-  // Allow both websocket and polling transports for Socket.IO
   transports: ['websocket', 'polling'],
+  pingInterval: 60_000,
+  pingTimeout: 30_000,
 })
 export class PorticoGateway
   implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
@@ -34,10 +34,6 @@ export class PorticoGateway
   server!: Server;
 
   private connectionCount = 0;
-  private pingInterval!: ReturnType<typeof setInterval>;
-  private entityPingInterval!: ReturnType<typeof setInterval>;
-  private cleanupInterval!: ReturnType<typeof setInterval>;
-  private fileCheckInterval!: ReturnType<typeof setInterval>;
 
   constructor(
     private readonly sessionService: SessionService,
@@ -52,26 +48,6 @@ export class PorticoGateway
   afterInit(server: Server) {
     this.roomService.setServer(server);
     this.notificationService.setServer(server);
-
-    // Server ping every 60s
-    this.pingInterval = setInterval(() => {
-      this.notificationService.sendServerPing();
-    }, 60_000);
-
-    // Entity room ping every 4min
-    this.entityPingInterval = setInterval(() => {
-      this.roomService.pingEntityRooms();
-    }, 240_000);
-
-    // Cleanup inactive connections every 8min
-    this.cleanupInterval = setInterval(() => {
-      this.roomService.cleanupInactiveConnections(480_000);
-    }, 480_000);
-
-    // File-based notification fallback every 1s
-    this.fileCheckInterval = setInterval(() => {
-      this.notificationService.checkNotificationFiles();
-    }, 1_000);
 
     // Register handler for partial application update requests from Redis
     this.notificationService.onPartialApplicationsUpdate(
@@ -107,7 +83,6 @@ export class PorticoGateway
     if (session.sessionId) {
       const roomId = this.roomService.sessionRoomId(session.sessionId);
       client.join(roomId);
-      this.roomService.trackClient(roomId, client.id);
 
       client.emit('message', {
         type: 'room_joined',
@@ -124,7 +99,7 @@ export class PorticoGateway
         message: 'Successfully connected to WebSocket server',
         roomId,
         timestamp: new Date().toISOString(),
-        rooms: this.getClientRoomsInfo(client.id),
+        rooms: this.getClientRoomsInfo(client),
         environment: this.getEnvironmentInfo(),
       });
     }
@@ -140,7 +115,7 @@ export class PorticoGateway
       `Disconnect: ${client.id} (remaining: ${this.connectionCount}, duration: ${duration}s)`,
     );
 
-    this.roomService.untrackClientFromAll(client.id);
+    // Socket.IO automatically removes client from all rooms on disconnect
     this.sessionService.removeSession(client.id);
   }
 
@@ -168,9 +143,8 @@ export class PorticoGateway
       case 'update_session':
         return this.handleUpdateSession(client, data);
       case 'room_ping_response':
-        return this.handleRoomPingResponse(client, data);
       case 'pong':
-        return this.handlePong(client, data);
+        return; // No-op: Socket.IO's built-in heartbeat handles liveness
       case 'update_user_info':
         return this.handleUpdateUserInfo(client, data);
       case 'get_partial_applications':
@@ -180,14 +154,7 @@ export class PorticoGateway
       case 'create_simple_application':
         return this.handleCreateSimpleApplication(client, data);
       case 'ping':
-        // Respond with pong (mirrors PHP NotificationService behavior)
-        client.emit('message', {
-          type: 'pong',
-          timestamp: new Date().toISOString(),
-          id: `pong_${Date.now()}`,
-          reply_to: data.id || null,
-        });
-        return;
+        return; // No-op: Socket.IO handles heartbeat natively
       default:
         // Forward to all other clients (like PHP's notificationService.processMessage)
         client.broadcast.emit('message', data);
@@ -200,7 +167,6 @@ export class PorticoGateway
 
     const roomId = this.roomService.entityRoomId(entityType, entityId);
     client.join(roomId);
-    this.roomService.trackClient(roomId, client.id);
 
     this.logger.debug(
       `${client.id} subscribed to ${entityType}:${entityId}`,
@@ -232,7 +198,6 @@ export class PorticoGateway
 
     const roomId = this.roomService.entityRoomId(entityType, entityId);
     client.leave(roomId);
-    this.roomService.untrackClient(roomId, client.id);
 
     client.emit('message', {
       type: 'subscription_confirmation',
@@ -247,8 +212,7 @@ export class PorticoGateway
     const { roomId } = data;
     if (!roomId) return;
 
-    const clientRooms = this.roomService.getClientRooms(client.id);
-    if (clientRooms.includes(roomId)) {
+    if (client.rooms.has(roomId)) {
       client.to(roomId).emit('message', data);
     } else {
       client.emit('message', {
@@ -275,9 +239,7 @@ export class PorticoGateway
     if (!entityType || !entityId) return;
 
     const roomId = this.roomService.entityRoomId(entityType, entityId);
-    if (this.roomService.roomExists(roomId)) {
-      client.to(roomId).emit('message', data);
-    }
+    client.to(roomId).emit('message', data);
   }
 
   private handleUpdateSession(client: Socket, data: any) {
@@ -331,23 +293,9 @@ export class PorticoGateway
       wasRequired,
       sessionId: sessionId.substring(0, 8) + '...',
       timestamp: new Date().toISOString(),
-      rooms: this.getClientRoomsInfo(client.id),
+      rooms: this.getClientRoomsInfo(client),
       environment: this.getEnvironmentInfo(),
     });
-  }
-
-  private handleRoomPingResponse(client: Socket, data: any) {
-    if (data.roomId) {
-      this.roomService.updateActivity(data.roomId, client.id);
-    }
-  }
-
-  private handlePong(client: Socket, data: any) {
-    // Log round-trip time if available
-    if (data.client_timestamp) {
-      const rtt = Date.now() - data.client_timestamp;
-      this.logger.debug(`Pong from ${client.id}: RTT ${rtt}ms`);
-    }
   }
 
   private handleUpdateUserInfo(client: Socket, data: any) {
@@ -597,13 +545,15 @@ export class PorticoGateway
   // --- Helpers ---
 
   private getClientRoomsInfo(
-    clientId: string,
+    client: Socket,
   ): Array<{ id: string; size: number; type: string }> {
-    return this.roomService.getClientRooms(clientId).map((roomId) => ({
-      id: roomId,
-      size: this.roomService.getRoomSize(roomId),
-      type: roomId.startsWith('session_') ? 'session' : 'entity',
-    }));
+    return Array.from(client.rooms)
+      .filter((roomId) => roomId !== client.id) // exclude the default self-room
+      .map((roomId) => ({
+        id: roomId,
+        size: this.roomService.getRoomSize(roomId),
+        type: roomId.startsWith('session_') ? 'session' : 'entity',
+      }));
   }
 
   private getEnvironmentInfo() {

--- a/src/WebSocket/node/src/modules/notification/notification.service.ts
+++ b/src/WebSocket/node/src/modules/notification/notification.service.ts
@@ -1,7 +1,5 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Server } from 'socket.io';
-import * as fs from 'fs';
-import * as path from 'path';
 import { RedisService } from './redis.service';
 import { RoomService } from '../session/room.service';
 
@@ -140,68 +138,5 @@ export class NotificationService implements OnModuleInit {
     }
   }
 
-  /**
-   * Check for file-based notification fallback (same as PHP).
-   */
-  checkNotificationFiles() {
-    if (!this.server) return;
 
-    // General notifications
-    this.processFilePattern('/tmp/websocket_notification_*.json', (data) => {
-      this.server!.emit('message', data);
-    });
-
-    // Session-specific notifications
-    this.processFilePattern('/tmp/websocket_session_*.json', (data) => {
-      if (data.sessionId) {
-        const roomId = this.roomService.sessionRoomId(data.sessionId);
-        this.server!.to(roomId).emit('message', data);
-      }
-    });
-  }
-
-  private processFilePattern(
-    pattern: string,
-    handler: (data: any) => void,
-  ) {
-    // Convert glob pattern to a directory + prefix scan
-    const dir = path.dirname(pattern);
-    const prefix = path.basename(pattern).replace('*.json', '');
-
-    let files: string[];
-    try {
-      files = fs
-        .readdirSync(dir)
-        .filter((f) => f.startsWith(prefix) && f.endsWith('.json'));
-    } catch {
-      return;
-    }
-
-    for (const file of files) {
-      const fullPath = path.join(dir, file);
-      try {
-        const content = fs.readFileSync(fullPath, 'utf-8');
-        const data = JSON.parse(content);
-        handler(data);
-        fs.unlinkSync(fullPath);
-      } catch (err: any) {
-        this.logger.error(
-          `Error processing notification file ${file}: ${err.message}`,
-        );
-      }
-    }
-  }
-
-  /**
-   * Send server ping to all connected clients.
-   */
-  sendServerPing() {
-    if (!this.server) return;
-    const pingId = `ping_${Date.now()}`;
-    this.server.emit('message', {
-      type: 'server_ping',
-      id: pingId,
-      timestamp: new Date().toISOString(),
-    });
-  }
 }

--- a/src/WebSocket/node/src/modules/session/room.service.ts
+++ b/src/WebSocket/node/src/modules/session/room.service.ts
@@ -1,17 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Server } from 'socket.io';
 
 @Injectable()
 export class RoomService {
-  private readonly logger = new Logger(RoomService.name);
-
-  /**
-   * Track which clients are in which rooms.
-   * Socket.IO manages actual room membership — this map is for
-   * metadata like activity timestamps and quick lookups.
-   */
-  private roomClients = new Map<string, Map<string, { joinedAt: number; lastActivity: number }>>();
-
   private server: Server | null = null;
 
   setServer(server: Server) {
@@ -26,149 +17,7 @@ export class RoomService {
     return `entity_${entityType}_${entityId}`;
   }
 
-  trackClient(roomId: string, clientId: string) {
-    if (!this.roomClients.has(roomId)) {
-      this.roomClients.set(roomId, new Map());
-    }
-    const now = Date.now();
-    this.roomClients.get(roomId)!.set(clientId, {
-      joinedAt: now,
-      lastActivity: now,
-    });
-  }
-
-  untrackClient(roomId: string, clientId: string) {
-    const room = this.roomClients.get(roomId);
-    if (room) {
-      room.delete(clientId);
-      if (room.size === 0) {
-        this.roomClients.delete(roomId);
-      }
-    }
-  }
-
-  untrackClientFromAll(clientId: string) {
-    for (const [roomId, clients] of this.roomClients) {
-      clients.delete(clientId);
-      if (clients.size === 0) {
-        this.roomClients.delete(roomId);
-      }
-    }
-  }
-
-  updateActivity(roomId: string, clientId: string) {
-    const room = this.roomClients.get(roomId);
-    const entry = room?.get(clientId);
-    if (entry) {
-      entry.lastActivity = Date.now();
-    }
-  }
-
   getRoomSize(roomId: string): number {
-    return this.roomClients.get(roomId)?.size ?? 0;
-  }
-
-  roomExists(roomId: string): boolean {
-    return this.roomClients.has(roomId) && this.roomClients.get(roomId)!.size > 0;
-  }
-
-  getClientRooms(clientId: string): string[] {
-    const rooms: string[] = [];
-    for (const [roomId, clients] of this.roomClients) {
-      if (clients.has(clientId)) {
-        rooms.push(roomId);
-      }
-    }
-    return rooms;
-  }
-
-  getAllRooms(): Array<{ id: string; clients: number; isSessionRoom: boolean }> {
-    const rooms: Array<{ id: string; clients: number; isSessionRoom: boolean }> = [];
-    for (const [roomId, clients] of this.roomClients) {
-      rooms.push({
-        id: roomId,
-        clients: clients.size,
-        isSessionRoom: roomId.startsWith('session_'),
-      });
-    }
-    return rooms;
-  }
-
-  getEntityRooms(): Array<{ id: string; clients: number }> {
-    return this.getAllRooms().filter(
-      (r) => !r.isSessionRoom && r.id.startsWith('entity_'),
-    );
-  }
-
-  /**
-   * Remove clients that haven't responded to pings within the threshold.
-   */
-  cleanupInactiveConnections(thresholdMs: number): {
-    connectionsRemoved: number;
-    roomsCleaned: string[];
-  } {
-    const now = Date.now();
-    let connectionsRemoved = 0;
-    const roomsCleaned: string[] = [];
-
-    for (const [roomId, clients] of this.roomClients) {
-      // Skip session rooms — they should persist as long as the connection is alive
-      if (roomId.startsWith('session_')) continue;
-
-      for (const [clientId, meta] of clients) {
-        if (now - meta.lastActivity > thresholdMs) {
-          clients.delete(clientId);
-          connectionsRemoved++;
-
-          // Also disconnect from Socket.IO room
-          try {
-            const sockets = this.server?.sockets?.sockets;
-            if (sockets) {
-              const socket = sockets.get(clientId);
-              if (socket) {
-                socket.leave(roomId);
-              }
-            }
-          } catch {
-            // Socket may already be disconnected
-          }
-        }
-      }
-
-      if (clients.size === 0) {
-        this.roomClients.delete(roomId);
-        roomsCleaned.push(roomId);
-      }
-    }
-
-    if (connectionsRemoved > 0) {
-      this.logger.log(
-        `Cleanup: removed ${connectionsRemoved} inactive connections from ${roomsCleaned.length} rooms`,
-      );
-    }
-
-    return { connectionsRemoved, roomsCleaned };
-  }
-
-  /**
-   * Send a ping to all clients in entity rooms.
-   */
-  pingEntityRooms() {
-    if (!this.server) return;
-
-    const entityRooms = this.getEntityRooms();
-    if (entityRooms.length === 0) return;
-
-    this.logger.debug(`Pinging ${entityRooms.length} entity rooms`);
-
-    for (const room of entityRooms) {
-      const pingId = `ping_${room.id}_${Date.now()}`;
-      this.server.to(room.id).emit('message', {
-        type: 'room_ping',
-        roomId: room.id,
-        pingId,
-        timestamp: new Date().toISOString(),
-      });
-    }
+    return this.server?.sockets?.adapter?.rooms?.get(roomId)?.size ?? 0;
   }
 }

--- a/src/WebSocket/node/src/modules/session/session.service.ts
+++ b/src/WebSocket/node/src/modules/session/session.service.ts
@@ -98,7 +98,6 @@ export class SessionService {
     if (oldSessionId) {
       const oldRoomId = roomService.sessionRoomId(oldSessionId);
       client.leave(oldRoomId);
-      roomService.untrackClient(oldRoomId, client.id);
     }
 
     // Update session data
@@ -114,7 +113,6 @@ export class SessionService {
     // Join new session room
     const newRoomId = roomService.sessionRoomId(newSessionId);
     client.join(newRoomId);
-    roomService.trackClient(newRoomId, client.id);
 
     this.logger.log(
       `Session updated for ${client.id}: ${oldSessionId ? oldSessionId.substring(0, 8) + '...' : 'none'} -> ${newSessionId.substring(0, 8)}...`,

--- a/src/modules/bookingfrontend/client/src/service/hooks/api-hooks.ts
+++ b/src/modules/bookingfrontend/client/src/service/hooks/api-hooks.ts
@@ -1450,8 +1450,10 @@ function createSimpleApplicationViaWs(
 	sendMessage: (type: string, message: string, additionalData?: Record<string, any>) => boolean,
 	timeslot: IFreeTimeSlot,
 	buildingId: number,
+	queryClient: ReturnType<typeof useQueryClient>,
 ): Promise<{ id: number; status: string; message: string }> {
 	const subscriptionManager = SubscriptionManager.getInstance();
+	const requestId = `booking_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
 	return new Promise((resolve, reject) => {
 		const timeout = setTimeout(() => {
@@ -1463,16 +1465,62 @@ function createSimpleApplicationViaWs(
 			'create_application_response',
 			(message) => {
 				if (message.type !== 'create_application_response') return;
+				// Only match our request
+				if (message.requestId !== requestId) return;
 				clearTimeout(timeout);
 				cleanup();
 				if (message.data.error === false) {
+					const appId = message.data.id!;
+
+					// Optimistically patch the timeslot cache immediately —
+					// don't wait for the slower partial_applications_response + room_message
+					const resourceId = String(timeslot.resource_id);
+					const allQueries = queryClient.getQueriesData<FreeTimeSlotsResponse>({
+						queryKey: ['buildingFreeTime', buildingId],
+					});
+					for (const [qk, data] of allQueries) {
+						if (!data?.[resourceId]) continue;
+						queryClient.setQueryData(qk, patchWeekCache(data, {
+							[resourceId]: [{
+								start: timeslot.start,
+								end: timeslot.end,
+								when: timeslot.when,
+								start_iso: timeslot.start_iso,
+								end_iso: timeslot.end_iso,
+								overlap: 2,
+								overlap_reason: 'complete_overlap',
+								overlap_type: 'complete',
+								overlap_event: {
+									id: appId,
+									type: 'application',
+									status: 'NEWPARTIAL1',
+									from: timeslot.start,
+									to: timeslot.end,
+								},
+							}],
+						}));
+					}
+
+					// Optimistically add to partial applications so the delete button shows
+					queryClient.setQueryData<{ list: IApplication[], total_sum: number }>(
+						['partialApplications'],
+						(prev) => {
+							if (!prev) return prev;
+							// Add a minimal placeholder — the full data arrives with partial_applications_response
+							const placeholder = { id: appId, status: 'NEWPARTIAL1' } as IApplication;
+							return {
+								list: [...prev.list, placeholder],
+								total_sum: prev.total_sum,
+							};
+						},
+					);
+
 					resolve({
 						id: message.data.id!,
 						status: message.data.status || 'NEWPARTIAL1',
 						message: message.data.message || 'Created',
 					});
 				} else if ((message.data as any).useRestFallback) {
-					// Server says PHP source changed — fall back to REST
 					reject(new Error('WS booking timeout'));
 				} else {
 					reject(new Error(message.data.message || 'Booking failed'));
@@ -1485,6 +1533,7 @@ function createSimpleApplicationViaWs(
 			buildingId,
 			from: timeslot.start,
 			to: timeslot.end,
+			requestId,
 		});
 	});
 }
@@ -1501,7 +1550,7 @@ export function useCreateSimpleApplication() {
 			if (isWebSocketActive) {
 				try {
 					return await createSimpleApplicationViaWs(
-						sendMessage, params.timeslot, params.building_id,
+						sendMessage, params.timeslot, params.building_id, queryClient,
 					);
 				} catch (err) {
 					// If the WS error is a real booking error (not a timeout), throw it

--- a/src/modules/bookingfrontend/client/src/service/websocket/socketio-context.tsx
+++ b/src/modules/bookingfrontend/client/src/service/websocket/socketio-context.tsx
@@ -14,10 +14,17 @@ import { WebSocketService } from './websocket-service';
 import { SubscriptionManager } from './subscription-manager';
 import { useWebSocketSession } from '../hooks/use-websocket-session';
 import { useCacheInvalidation } from '@/service/hooks/use-cache-invalidation';
-import { wsLog as wslogbase } from './util';
+import { wsLog as wslogbase, SOCKETIO_TRAFFIC_DEBUG } from './util';
 
 const wsLog = (message: string, ...args: any[]) =>
   wslogbase('SocketIO', message, ...args);
+
+const trafficLog = (direction: 'TX' | 'RX', type: string, data: any) => {
+  if (!SOCKETIO_TRAFFIC_DEBUG) return;
+  const ts = new Date().toISOString().split('T')[1].substring(0, 12);
+  const arrow = direction === 'TX' ? '\x1b[36m>>>\x1b[0m' : '\x1b[33m<<<\x1b[0m';
+  console.log(`[SIO ${ts}] ${arrow} ${type}`, data);
+};
 
 interface SocketIOProviderProps {
   children: ReactNode;
@@ -73,13 +80,16 @@ export const SocketIOProvider: React.FC<SocketIOProviderProps> = ({
         wsLog('Session ID required');
         break;
 
-      case 'server_ping':
-        socketRef.current?.emit('message', {
+      case 'server_ping': {
+        const pong = {
           type: 'pong',
           timestamp: new Date().toISOString(),
           reply_to: data.id || null,
-        });
+        };
+        trafficLog('TX', 'pong', pong);
+        socketRef.current?.emit('message', pong);
         break;
+      }
 
       case 'reconnect_required':
         wsLog('Server requested reconnection');
@@ -129,6 +139,7 @@ export const SocketIOProvider: React.FC<SocketIOProviderProps> = ({
 
     const directMessageHandler = (event: any) => {
       if (socket.connected && event.data) {
+        trafficLog('TX', event.data.type || 'direct', event.data);
         socket.emit('message', event.data);
       }
     };
@@ -143,13 +154,15 @@ export const SocketIOProvider: React.FC<SocketIOProviderProps> = ({
       const subs = subscriptionManager.current.getActiveEntitySubscriptions();
       subs.forEach((sub, i) => {
         setTimeout(() => {
-          socket.emit('message', {
+          const payload = {
             type: 'subscribe',
             message: `Subscribing to ${sub.entityType} ${sub.entityId}`,
             entityType: sub.entityType,
             entityId: sub.entityId,
             timestamp: new Date().toISOString(),
-          });
+          };
+          trafficLog('TX', 'subscribe', payload);
+          socket.emit('message', payload);
         }, i * 50);
       });
     });
@@ -179,6 +192,7 @@ export const SocketIOProvider: React.FC<SocketIOProviderProps> = ({
     });
 
     socket.on('message', (data: WebSocketMessage) => {
+      trafficLog('RX', data.type || 'unknown', data);
       handleMessage(data);
     });
 
@@ -202,12 +216,14 @@ export const SocketIOProvider: React.FC<SocketIOProviderProps> = ({
         return false;
       }
 
-      socket.emit('message', {
+      const payload = {
         type,
         message,
         ...additionalData,
         timestamp: new Date().toISOString(),
-      });
+      };
+      trafficLog('TX', type, payload);
+      socket.emit('message', payload);
       return true;
     },
     [],

--- a/src/modules/bookingfrontend/client/src/service/websocket/util.ts
+++ b/src/modules/bookingfrontend/client/src/service/websocket/util.ts
@@ -3,6 +3,9 @@
 // Toggle for client-side WebSocket logging
 export const WEBSOCKET_CLIENT_DEBUG = false;
 
+// Toggle for logging ALL Socket.IO traffic (every emit/receive)
+export const SOCKETIO_TRAFFIC_DEBUG = true;
+
 /**
  * Helper function for consistent WebSocket logging
  * @param area the component responsible

--- a/src/modules/bookingfrontend/client/src/service/websocket/websocket.types.ts
+++ b/src/modules/bookingfrontend/client/src/service/websocket/websocket.types.ts
@@ -177,6 +177,7 @@ export interface IWSFreeTimeResponse extends IWebSocketMessageBase {
 // Interface for create application response
 export interface IWSCreateApplicationResponse extends IWebSocketMessageBase {
   type: 'create_application_response';
+  requestId?: string;
   data: {
     error: boolean;
     message?: string;


### PR DESCRIPTION
- Replace custom room tracking (roomClients map) with Socket.IO native socket.rooms and adapter.rooms
- Configure @socket.io/redis-adapter for multi-instance room sync
- Remove custom ping/heartbeat intervals, use Socket.IO pingInterval
- Remove file-based notification fallback polling
- Add Socket.IO traffic debug logging (SOCKETIO_TRAFFIC_DEBUG toggle)
- Add requestId to create_simple_application for response matching
- Optimistically update timeslot + partial apps cache on booking response for instant UI feedback (delete button appears ~2s faster)