### PR TITLE
Add WebSocket delete for partial applications

### DIFF
--- a/src/WebSocket/node/src/modules/booking/booking.service.ts
+++ b/src/WebSocket/node/src/modules/booking/booking.service.ts
@@ -802,6 +802,201 @@ export class BookingService implements OnModuleInit {
     });
   }
 
+  /**
+   * Delete a partial application. Port of PHP ApplicationController::deletePartial.
+   * Verifies the session owns the application, deletes all associated data,
+   * clears blocks, and publishes notifications.
+   */
+  /**
+   * Delete a partial application. Port of PHP ApplicationController::deletePartial.
+   * Verifies the session owns the application, deletes all associated data,
+   * clears blocks/locks for ALL resource+date combos, and publishes notifications.
+   */
+  async deletePartialApplication(
+    applicationId: number,
+    sessionId: string,
+  ): Promise<{
+    deleted: boolean;
+    buildingId: number | null;
+    resourceIds: number[];
+    dates: Array<{ from_: string; to_: string }>;
+  }> {
+    let client: any = null;
+    try {
+      client = await this.db.getClient();
+      await client.query('BEGIN');
+
+      // PHP: $application = $this->applicationService->getApplicationById($id)
+      const appResult = await client.query(
+        `SELECT a.id, a.session_id, a.building_id, a.status
+         FROM bb_application a
+         WHERE a.id = $1 AND a.status = 'NEWPARTIAL1'`,
+        [applicationId],
+      );
+      if (appResult.rows.length === 0) {
+        await client.query('ROLLBACK');
+        throw new TranslatableError('Application not found or not a partial application', 'application_not_found');
+      }
+      const app = appResult.rows[0];
+
+      // PHP: $this->applicationHelper->canModifyApplication($application, $request)
+      // For NEWPARTIAL1, the check is session_id match
+      if (app.session_id !== sessionId) {
+        await client.query('ROLLBACK');
+        throw new TranslatableError('Unauthorized to delete this application', 'unauthorized');
+      }
+
+      // PHP: $dates = $this->applicationService->applicationRepository->fetchDates($id)
+      const { rows: dates } = await client.query(
+        `SELECT from_, to_ FROM bb_application_date WHERE application_id = $1`,
+        [applicationId],
+      );
+      // PHP: $resources = $this->applicationService->applicationRepository->fetchResources($id)
+      const { rows: resources } = await client.query(
+        `SELECT resource_id FROM bb_application_resource WHERE application_id = $1`,
+        [applicationId],
+      );
+
+      const buildingId = app.building_id;
+      const resourceIds = resources.map((r: any) => r.resource_id);
+
+      // PHP: $this->applicationService->deletePartial($id)
+      // Which calls deleteAssociatedData then deletes the application
+      // Note: PHP also deletes bb_document_application via DocumentService
+      // (skipped here — simple bookings don't have documents)
+      await client.query(
+        `DELETE FROM bb_purchase_order_line WHERE order_id IN
+         (SELECT id FROM bb_purchase_order WHERE application_id = $1)`,
+        [applicationId],
+      );
+      await client.query(`DELETE FROM bb_purchase_order WHERE application_id = $1`, [applicationId]);
+      await client.query(`DELETE FROM bb_application_comment WHERE application_id = $1`, [applicationId]);
+      await client.query(`DELETE FROM bb_application_date WHERE application_id = $1`, [applicationId]);
+      await client.query(`DELETE FROM bb_application_resource WHERE application_id = $1`, [applicationId]);
+      await client.query(`DELETE FROM bb_application_targetaudience WHERE application_id = $1`, [applicationId]);
+      await client.query(`DELETE FROM bb_application_agegroup WHERE application_id = $1`, [applicationId]);
+      await client.query(`DELETE FROM bb_application WHERE id = $1`, [applicationId]);
+
+      await client.query('COMMIT');
+
+      // PHP: Clear blocks for EACH resource and date (nested foreach)
+      // Done after commit, matching PHP which does it after deletePartial returns
+      for (const resource of resources) {
+        for (const date of dates) {
+          // PHP: clearBlocksAndLocks — clears DB blocks + Redis cache keys
+          try {
+            await client.query(
+              `UPDATE bb_block SET active = 0
+               WHERE session_id = $1 AND resource_id = $2 AND from_ = $3 AND to_ = $4`,
+              [sessionId, resource.resource_id, date.from_, date.to_],
+            );
+
+            // PHP: Cache::system_clear('booking', "timeslot_lock_{$resourceId}_{$from}_{$to}")
+            const lockKey = this.genRedisKey('booking', `timeslot_lock_${resource.resource_id}_${date.from_}_${date.to_}`);
+            await this.redisService.releaseLock(lockKey, sessionId).catch(() => {});
+          } catch (err: any) {
+            this.logger.error(`Error clearing blocks for resource ${resource.resource_id}: ${err.message}`);
+          }
+        }
+      }
+
+      this.logger.log(`Partial application #${applicationId} deleted`);
+
+      return {
+        deleted: true,
+        buildingId,
+        resourceIds,
+        dates: dates.map((d: any) => ({ from_: String(d.from_), to_: String(d.to_) })),
+      };
+    } catch (err) {
+      if (client) await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      if (client) client.release();
+    }
+  }
+
+  /**
+   * Publish notifications after deleting a partial application.
+   */
+  /**
+   * Publish notifications after deleting a partial application.
+   * Matches PHP: fetches affected timeslots per resource, notifies building + each resource room.
+   */
+  async publishDeletionNotifications(
+    buildingId: number,
+    resourceIds: number[],
+    dates: Array<{ from_: string; to_: string }>,
+    applicationId: number,
+  ): Promise<void> {
+    if (dates.length === 0 || resourceIds.length === 0) return;
+
+    // PHP: uses first date's from/to for the query range
+    const from = dates[0].from_;
+    const to = dates[0].to_;
+    const fromDate = new Date(from.includes('T') ? from : from.replace(' ', 'T'));
+    const toDate = new Date(to.includes('T') ? to : to.replace(' ', 'T'));
+    const queryStart = new Date(fromDate);
+    queryStart.setDate(queryStart.getDate() - 1);
+    const queryEnd = new Date(toDate);
+    queryEnd.setDate(queryEnd.getDate() + 1);
+
+    const queryStartStr = queryStart.toISOString().slice(0, 10);
+    const queryEndStr = queryEnd.toISOString().slice(0, 10);
+
+    // PHP: foreach resourceIds, get affected timeslots
+    const affectedTimeslots: Record<string, any[]> = {};
+    for (const resId of resourceIds) {
+      try {
+        const timeslots = await this.freeTimeService.getFreeTime(
+          buildingId, resId, queryStartStr, queryEndStr, null, true, true,
+        );
+        if (timeslots[resId]) {
+          affectedTimeslots[resId] = timeslots[resId];
+        }
+      } catch (err: any) {
+        this.logger.error(`Failed to get affected timeslots for resource ${resId}: ${err.message}`);
+      }
+    }
+
+    const eventData = {
+      application_id: applicationId,
+      from, to,
+      change_type: 'deletion',
+      affected_timeslots: affectedTimeslots,
+    };
+
+    // PHP: WebSocketHelper::sendEntityNotification('building', ...)
+    await this.redisService.publish('room_messages', {
+      type: 'room_message',
+      roomId: `entity_building_${buildingId}`,
+      entityType: 'building',
+      entityId: buildingId,
+      action: 'deleted',
+      message: 'Application deleted',
+      data: eventData,
+      timestamp: new Date().toISOString(),
+    });
+
+    // PHP: foreach resourceIds, notify each resource room
+    for (const resId of resourceIds) {
+      await this.redisService.publish('room_messages', {
+        type: 'room_message',
+        roomId: `entity_resource_${resId}`,
+        entityType: 'resource',
+        entityId: resId,
+        action: 'deleted',
+        message: 'Application deleted',
+        data: {
+          ...eventData,
+          resource_id: resId,
+          affected_timeslots: affectedTimeslots[resId] ?? [],
+        },
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
   // --- Private helpers (1:1 ports of PHP methods) ---
 
   /**

--- a/src/WebSocket/node/src/modules/gateway/portico.gateway.ts
+++ b/src/WebSocket/node/src/modules/gateway/portico.gateway.ts
@@ -153,6 +153,8 @@ export class PorticoGateway
         return this.handleGetFreeTime(client, data);
       case 'create_simple_application':
         return this.handleCreateSimpleApplication(client, data);
+      case 'delete_partial_application':
+        return this.handleDeletePartialApplication(client, data);
       case 'ping':
         return; // No-op: Socket.IO handles heartbeat natively
       default:
@@ -490,6 +492,77 @@ export class PorticoGateway
             translatable: isTranslatable,
           },
         ],
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  private async handleDeletePartialApplication(client: Socket, data: any) {
+    const { applicationId, requestId } = data;
+
+    if (!applicationId) {
+      client.emit('message', {
+        type: 'delete_application_response',
+        data: { error: true, message: 'applicationId is required' },
+        ...(requestId && { requestId }),
+        timestamp: new Date().toISOString(),
+      });
+      return;
+    }
+
+    const session = this.sessionService.getSession(client.id);
+    if (!session?.sessionId) {
+      client.emit('message', {
+        type: 'delete_application_response',
+        data: { error: true, message: 'No session' },
+        ...(requestId && { requestId }),
+        timestamp: new Date().toISOString(),
+      });
+      return;
+    }
+
+    try {
+      const result = await this.bookingService.deletePartialApplication(
+        Number(applicationId),
+        session.sessionId,
+      );
+
+      client.emit('message', {
+        type: 'delete_application_response',
+        data: {
+          error: false,
+          id: applicationId,
+          message: 'Application deleted successfully',
+        },
+        ...(requestId && { requestId }),
+        timestamp: new Date().toISOString(),
+      });
+
+      // Push updated partial applications (with diff) then publish timeslot notifications
+      this.sendPartialApplicationsUpdate(session.sessionId!, { removed: [Number(applicationId)] })
+        .then(() => {
+          if (result.buildingId && result.resourceIds.length > 0 && result.dates.length > 0) {
+            return this.bookingService.publishDeletionNotifications(
+              result.buildingId,
+              result.resourceIds,
+              result.dates,
+              Number(applicationId),
+            );
+          }
+        })
+        .catch((err) =>
+          this.logger.error(`Deletion notification error: ${err.message}`),
+        );
+    } catch (err: any) {
+      this.logger.warn(`Delete failed: ${err.message}`);
+
+      client.emit('message', {
+        type: 'delete_application_response',
+        data: {
+          error: true,
+          message: err.message,
+        },
+        ...(requestId && { requestId }),
         timestamp: new Date().toISOString(),
       });
     }

--- a/src/modules/bookingfrontend/client/src/service/api/api-utils.ts
+++ b/src/modules/bookingfrontend/client/src/service/api/api-utils.ts
@@ -772,41 +772,87 @@ export async function fetchBuildingAudience(building_id: number): Promise<IAudie
     return result;
 }
 
+function deletePartialViaWsStandalone(id: number): Promise<void> {
+    // Lazy import to avoid circular deps
+    const { WebSocketService } = require('@/service/websocket/websocket-service');
+    const { SubscriptionManager } = require('@/service/websocket/subscription-manager');
+
+    const wsService = WebSocketService.getInstance();
+    if (!wsService.isReady()) return Promise.reject(new Error('WS not ready'));
+
+    const subscriptionManager = SubscriptionManager.getInstance();
+    const requestId = `delete_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+    return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+            cleanup();
+            reject(new Error('WS delete timeout'));
+        }, 15000);
+
+        const cleanup = subscriptionManager.subscribeToMessageType(
+            'delete_application_response',
+            (message: any) => {
+                if (message.type !== 'delete_application_response') return;
+                if (message.requestId !== requestId) return;
+                clearTimeout(timeout);
+                cleanup();
+                if (message.data.error === false) {
+                    resolve();
+                } else {
+                    reject(new Error(message.data.message || 'Delete failed'));
+                }
+            },
+        );
+
+        wsService.sendMessage('delete_partial_application', 'Deleting partial application', {
+            applicationId: id,
+            requestId,
+        });
+    });
+}
+
 export async function deletePartialApplication(id: number): Promise<void> {
+    const { pendingDeletions } = require('@/service/hooks/pending-deletions');
     const queryClient = getQueryClient();
+    pendingDeletions.add(id);
 
     // Get current cart data before API call
     const currentData = queryClient.getQueryData<{ list: IApplication[], total_sum: number }>(['partialApplications']);
 
-    // If we have current data, update it optimistically
+    // Optimistically update
     if (currentData) {
         queryClient.setQueryData(['partialApplications'], {
             ...currentData,
             list: currentData.list.filter(item => item.id !== id),
-            total_sum: currentData.total_sum // Maintain current sum
+            total_sum: currentData.total_sum,
         });
     }
 
-    // Make the API call
-    const url = phpGWLink(['bookingfrontend', 'applications', id]);
-
     try {
+        // Try WebSocket first
+        try {
+            await deletePartialViaWsStandalone(id);
+            pendingDeletions.delete(id);
+            return;
+        } catch {
+            // Fall through to REST
+        }
+
+        // REST fallback
+        const url = phpGWLink(['bookingfrontend', 'applications', id]);
         const response = await fetch(url, {method: 'DELETE'});
         const result = await response.json();
 
-        // Refetch to ensure data consistency after successful delete
+        pendingDeletions.delete(id);
         queryClient.refetchQueries({queryKey: ['partialApplications']});
-
         return result;
     } catch (error) {
-        // If there was an error, roll back to original data
+        pendingDeletions.delete(id);
+        // Roll back on error
         if (currentData) {
             queryClient.setQueryData(['partialApplications'], currentData);
         }
-
-        // Refetch to ensure data consistency
         queryClient.refetchQueries({queryKey: ['partialApplications']});
-
         throw error;
     }
 }

--- a/src/modules/bookingfrontend/client/src/service/hooks/api-hooks.ts
+++ b/src/modules/bookingfrontend/client/src/service/hooks/api-hooks.ts
@@ -62,6 +62,7 @@ import {
 	useEntitySubscriptionWithPing
 } from './use-websocket-subscriptions';
 import {IWSServerDeletedMessage, IWSServerNewMessage, WebSocketMessage} from '../websocket/websocket.types';
+import { pendingDeletions } from './pending-deletions';
 
 /**
  * Custom hook that wraps useMutation and adds server message invalidation
@@ -910,9 +911,13 @@ export function usePartialApplications(): UseQueryResult<{ list: IApplication[],
 
 		// Also set the full list if seq is newest (authoritative update)
 		if (seq >= lastSeqRef.current) {
+			// Filter out any apps that are pending deletion client-side
+			const apps = pendingDeletions.size > 0
+				? message.data.applications.filter((a: IApplication) => !pendingDeletions.has(a.id))
+				: message.data.applications;
 			queryClient.setQueryData(['partialApplications'], {
-				list: message.data.applications,
-				total_sum: calcTotalSum(message.data.applications),
+				list: apps,
+				total_sum: calcTotalSum(apps),
 			});
 		}
 	});
@@ -1391,52 +1396,103 @@ export function useUpdatePartialApplication() {
 	});
 }
 
+function deletePartialViaWs(
+	sendMessage: (type: string, message: string, additionalData?: Record<string, any>) => boolean,
+	applicationId: number,
+): Promise<number> {
+	const subscriptionManager = SubscriptionManager.getInstance();
+	const requestId = `delete_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => {
+			cleanup();
+			reject(new Error('WebSocket delete timeout'));
+		}, 15000);
+
+		const cleanup = subscriptionManager.subscribeToMessageType(
+			'delete_application_response',
+			(message) => {
+				if (message.type !== 'delete_application_response') return;
+				if ((message as any).requestId !== requestId) return;
+				clearTimeout(timeout);
+				cleanup();
+				if (message.data.error === false) {
+					resolve(applicationId);
+				} else {
+					reject(new Error(message.data.message || 'Delete failed'));
+				}
+			},
+		);
+
+		sendMessage('delete_partial_application', 'Deleting partial application', {
+			applicationId,
+			requestId,
+		});
+	});
+}
+
 export function useDeletePartialApplication() {
 	const queryClient = useQueryClient();
-	const { status: wsStatus, sessionConnected, isReady: wsReady } = useWebSocketContext();
+	const { status: wsStatus, sessionConnected, isReady: wsReady, sendMessage } = useWebSocketContext();
 
 	return useServerMessageMutation({
 		mutationFn: async (id: number) => {
+			const isWebSocketActive = wsReady && wsStatus === 'OPEN' && sessionConnected;
+
+			if (isWebSocketActive) {
+				try {
+					return await deletePartialViaWs(sendMessage, id);
+				} catch (err) {
+					if (err instanceof Error && !err.message.includes('timeout')) {
+						throw err;
+					}
+				}
+			}
+
+			// REST fallback
 			const url = phpGWLink(['bookingfrontend', 'applications', id]);
 			const response = await fetch(url, {method: 'DELETE'});
-
 			if (!response.ok) {
 				throw new Error('Failed to delete partial application');
 			}
-
-			return id
+			return id;
 		},
 		onMutate: async (id: number) => {
-			// Cancel any outgoing refetches to avoid overwriting optimistic update
+			pendingDeletions.add(id);
 			await queryClient.cancelQueries({queryKey: ['partialApplications']});
 
-			// Snapshot current applications
 			const previousApplications = queryClient.getQueryData<{
 				list: IApplication[],
 				total_sum: number
 			}>(['partialApplications']);
 
-			// Optimistically update applications list
 			if (previousApplications) {
 				queryClient.setQueryData(['partialApplications'], {
 					...previousApplications,
-					list: previousApplications.list.filter(app =>
-						app.id !== id
-					),
+					list: previousApplications.list.filter(app => app.id !== id),
 				});
 			}
 
 			return {previousApplications};
 		},
-		onError: (err, variables, context) => {
-			// On error, rollback to previous state
+		onError: (_err, variables, context) => {
+			pendingDeletions.delete(variables);
 			if (context?.previousApplications) {
 				queryClient.setQueryData(['partialApplications'], context.previousApplications);
 			}
 		},
+		onSuccess: (_data, variables) => {
+			pendingDeletions.delete(variables);
+			const isWebSocketActive = wsReady && wsStatus === 'OPEN' && sessionConnected;
+			if (!isWebSocketActive) {
+				queryClient.invalidateQueries({queryKey: ['partialApplications']});
+			}
+		},
 		onSettled: () => {
-			// Always invalidate to ensure correctness after delete
-			queryClient.invalidateQueries({queryKey: ['partialApplications']});
+			const isWebSocketActive = wsReady && wsStatus === 'OPEN' && sessionConnected;
+			if (!isWebSocketActive) {
+				queryClient.invalidateQueries({queryKey: ['partialApplications']});
+			}
 		},
 	});
 }

--- a/src/modules/bookingfrontend/client/src/service/hooks/pending-deletions.ts
+++ b/src/modules/bookingfrontend/client/src/service/hooks/pending-deletions.ts
@@ -1,0 +1,6 @@
+/**
+ * Track application IDs that are pending deletion.
+ * Prevents server-pushed partial_applications_response from re-adding
+ * items that the user has already deleted but the server hasn't confirmed yet.
+ */
+export const pendingDeletions = new Set<number>();

--- a/src/modules/bookingfrontend/client/src/service/websocket/subscription-manager.ts
+++ b/src/modules/bookingfrontend/client/src/service/websocket/subscription-manager.ts
@@ -41,6 +41,7 @@ const SILENT_SOCKET_TYPES: Record<WebSocketMessage['type'], boolean> = {
 	partial_applications_response: false,
 	free_time_response: false,
 	create_application_response: false,
+	delete_application_response: false,
 	entity_event: false,
 	notification: false,
 	reconnect_required: false,

--- a/src/modules/bookingfrontend/client/src/service/websocket/websocket.types.ts
+++ b/src/modules/bookingfrontend/client/src/service/websocket/websocket.types.ts
@@ -186,6 +186,16 @@ export interface IWSCreateApplicationResponse extends IWebSocketMessageBase {
   };
 }
 
+export interface IWSDeleteApplicationResponse extends IWebSocketMessageBase {
+  type: 'delete_application_response';
+  requestId?: string;
+  data: {
+    error: boolean;
+    message?: string;
+    id?: number;
+  };
+}
+
 // Interface for booking user refresh message
 export interface IWSRefreshBookingUserMessage extends IWebSocketMessageBase {
   type: 'refresh_bookinguser';
@@ -221,6 +231,7 @@ export type WebSocketMessage =
   | IWSPartialApplicationsResponse
   | IWSFreeTimeResponse
   | IWSCreateApplicationResponse
+  | IWSDeleteApplicationResponse
   | IWSRefreshBookingUserMessage
   | IWSCacheInvalidationMessage;
   // | (IWebSocketMessageBase & { [key: string]: any }); // Catch-all for other message types


### PR DESCRIPTION
- Port PHP deletePartial logic to Node WS (1:1 match: session check, associated data cleanup, block clearing, Redis lock clearing, per-resource notifications)
- Client: both shopping cart (api-utils) and timeslot view (hook) try WS first, fall back to REST
- Add pendingDeletions set to prevent server pushes from re-adding items during rapid multi-delete