### PR TITLE
Add DTOs to match PHP serialization in WS partial applications

### DIFF
--- a/src/WebSocket/node/package.json
+++ b/src/WebSocket/node/package.json
@@ -17,6 +17,7 @@
     "@nestjs/platform-socket.io": "^11.0.0",
     "@nestjs/websockets": "^11.0.0",
     "@socket.io/redis-adapter": "^8.3.0",
+    "class-transformer": "^0.5.1",
     "ioredis": "^5.4.0",
     "pg": "^8.13.0",
     "reflect-metadata": "^0.2.0",

--- a/src/WebSocket/node/src/modules/application/application.service.ts
+++ b/src/WebSocket/node/src/modules/application/application.service.ts
@@ -1,62 +1,41 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { plainToInstance, instanceToPlain } from 'class-transformer';
 import { DatabaseService } from '../../database/database.service';
+import { ApplicationDto, OrderDto, OrderLineDto } from './dto';
 
-interface ApplicationDate {
-  id: number;
-  from_: string;
-  to_: string;
+/**
+ * Remove keys whose value is null/undefined, matching PHP SerializableTrait
+ * which skips properties where `$value !== null`.
+ */
+function stripNulls(obj: any): any {
+  if (Array.isArray(obj)) return obj.map(stripNulls);
+  if (obj && typeof obj === 'object') {
+    const out: any = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (v === null || v === undefined) continue;
+      out[k] = stripNulls(v);
+    }
+    return out;
+  }
+  return obj;
 }
 
-interface ApplicationResource {
-  id: number;
-  name: string;
-  building_id: number | null;
-  [key: string]: any;
-}
-
-interface OrderLine {
-  order_id: number;
-  article_mapping_id: number;
-  quantity: number;
-  unit_price: number;
-  name: string;
-  unit: string;
-  [key: string]: any;
-}
-
-interface Order {
-  order_id: number;
-  sum: number;
-  lines: OrderLine[];
-}
-
-interface ArticleOrder {
-  id: number;
-  quantity: number;
-  parent_id: number | null;
-  name: string;
-  unit: string;
-  article_cat_id: number;
-  article_id: number;
-  unit_price: number;
-  tax_code: number | null;
-  tax_percent: number | null;
-}
-
-interface AgeGroup {
-  id: number;
-  name: string;
-  sort: number;
-  male: number;
-  female: number;
-  [key: string]: any;
-}
-
-interface Document {
-  id: number;
-  name: string;
-  category: number;
-  [key: string]: any;
+/**
+ * Convert Date objects to raw DB-style strings (e.g. "2026-05-07 11:31:28.717852").
+ * The pg driver auto-parses timestamp columns into JS Date objects, but PHP
+ * passes them through as raw strings since there's no @Timestamp on these fields.
+ */
+function dateToDbString(value: any): string {
+  if (!(value instanceof Date)) return value;
+  const pad = (n: number, len = 2) => String(n).padStart(len, '0');
+  const y = value.getFullYear();
+  const mo = pad(value.getMonth() + 1);
+  const d = pad(value.getDate());
+  const h = pad(value.getHours());
+  const mi = pad(value.getMinutes());
+  const s = pad(value.getSeconds());
+  const ms = pad(value.getMilliseconds(), 3);
+  return `${y}-${mo}-${d} ${h}:${mi}:${s}.${ms}`;
 }
 
 @Injectable()
@@ -91,8 +70,24 @@ export class ApplicationService {
               this.fetchDocuments(app.id),
             ]);
 
-          return {
-            ...app,
+          // Pre-process fields that pg driver auto-converts but PHP keeps as raw strings
+          const preprocessed: Record<string, any> = { ...app };
+          if (preprocessed.created instanceof Date) {
+            preprocessed.created = dateToDbString(preprocessed.created);
+          }
+          if (preprocessed.modified instanceof Date) {
+            preprocessed.modified = dateToDbString(preprocessed.modified);
+          }
+          if (preprocessed.frontend_modified instanceof Date) {
+            preprocessed.frontend_modified = dateToDbString(preprocessed.frontend_modified);
+          }
+          // pg driver auto-parses JSON/JSONB — PHP keeps it as a raw string
+          if (preprocessed.recurring_info != null && typeof preprocessed.recurring_info !== 'string') {
+            preprocessed.recurring_info = JSON.stringify(preprocessed.recurring_info);
+          }
+
+          const plain = {
+            ...preprocessed,
             dates,
             resources,
             orders,
@@ -101,6 +96,12 @@ export class ApplicationService {
             audience,
             documents,
           };
+
+          const dto = plainToInstance(ApplicationDto, plain, {
+            excludeExtraneousValues: true,
+          });
+          const serialized = instanceToPlain(dto, { excludeExtraneousValues: true });
+          return stripNulls(serialized);
         }),
       );
 
@@ -116,7 +117,7 @@ export class ApplicationService {
     }
   }
 
-  private async fetchDates(applicationId: number): Promise<ApplicationDate[]> {
+  private async fetchDates(applicationId: number): Promise<any[]> {
     const { rows } = await this.db.query(
       `SELECT * FROM bb_application_date
        WHERE application_id = $1
@@ -126,9 +127,7 @@ export class ApplicationService {
     return rows;
   }
 
-  private async fetchResources(
-    applicationId: number,
-  ): Promise<ApplicationResource[]> {
+  private async fetchResources(applicationId: number): Promise<any[]> {
     const { rows } = await this.db.query(
       `SELECT r.*, br.building_id
        FROM bb_resource r
@@ -140,7 +139,16 @@ export class ApplicationService {
     return rows;
   }
 
-  private async fetchOrders(applicationId: number): Promise<Order[]> {
+  /**
+   * Fetch and group order lines into Order objects.
+   *
+   * PHP quirk: `SELECT po.*, pol.*` causes `pol.id` to overwrite `po.id`,
+   * then PHP groups by `$row['id']` — effectively grouping by the line's PK,
+   * so each line becomes its own "order". We replicate this behavior.
+   *
+   * PHP sum: $line->amount + $line->tax per line.
+   */
+  private async fetchOrders(applicationId: number): Promise<any[]> {
     const { rows } = await this.db.query(
       `SELECT po.*, pol.*, am.unit,
               CASE WHEN r.name IS NULL THEN s.name ELSE r.name END AS name
@@ -154,49 +162,52 @@ export class ApplicationService {
       [applicationId],
     );
 
-    // Group lines by order
-    const orderMap = new Map<number, Order>();
+    // PHP groups by $row['id'] which is pol.id (line PK) due to column collision.
+    // Each line becomes its own "order" with order_id = pol.id.
+    const orderMap = new Map<number, { order_id: number; sum: number; lines: any[] }>();
     for (const row of rows) {
-      const orderId = row.order_id;
-      if (!orderMap.has(orderId)) {
-        orderMap.set(orderId, {
-          order_id: orderId,
-          sum: 0,
-          lines: [],
-        });
+      // pol.id overwrites po.id in PHP's SELECT po.*, pol.*
+      const lineId = row.id;
+      if (!orderMap.has(lineId)) {
+        orderMap.set(lineId, { order_id: lineId, sum: 0, lines: [] });
       }
-      const order = orderMap.get(orderId)!;
-      order.lines.push(row);
-      order.sum += parseFloat(row.amount || '0');
+      const order = orderMap.get(lineId)!;
+
+      // Serialize line through OrderLineDto
+      const lineDto = plainToInstance(OrderLineDto, row, { excludeExtraneousValues: true });
+      order.lines.push(instanceToPlain(lineDto, { excludeExtraneousValues: true }));
+
+      order.sum += (parseFloat(row.amount || '0')) + (parseFloat(row.tax || '0'));
     }
 
-    return Array.from(orderMap.values());
+    // Serialize each order through OrderDto, strip nulls
+    return Array.from(orderMap.values()).map((order) => {
+      const dto = plainToInstance(OrderDto, order, { excludeExtraneousValues: true });
+      return stripNulls(instanceToPlain(dto, { excludeExtraneousValues: true }));
+    });
   }
 
-  private async fetchArticles(
-    applicationId: number,
-  ): Promise<ArticleOrder[]> {
+  /**
+   * Fetch articles matching PHP ArticleRepository::fetchArticlesForApplication —
+   * returns only {id, quantity, parent_id} with int casting.
+   */
+  private async fetchArticles(applicationId: number): Promise<any[]> {
     const { rows } = await this.db.query(
-      `SELECT pol.article_mapping_id as id, pol.quantity, pol.parent_mapping_id as parent_id,
-              CASE WHEN r.name IS NULL THEN s.name ELSE r.name END AS name,
-              am.unit, am.article_cat_id, am.article_id, pol.unit_price,
-              pol.tax_code, e.percent_ AS tax_percent
+      `SELECT pol.article_mapping_id as id, pol.quantity, pol.parent_mapping_id as parent_id
        FROM bb_purchase_order po
        JOIN bb_purchase_order_line pol ON po.id = pol.order_id
-       JOIN bb_article_mapping am ON pol.article_mapping_id = am.id
-       LEFT JOIN fm_ecomva e ON pol.tax_code = e.id
-       LEFT JOIN bb_service s ON (am.article_id = s.id AND am.article_cat_id = 2)
-       LEFT JOIN bb_resource r ON (am.article_id = r.id AND am.article_cat_id = 1)
        WHERE po.cancelled IS NULL AND po.application_id = $1
        ORDER BY pol.id`,
       [applicationId],
     );
-    return rows;
+    return rows.map((row) => ({
+      id: parseInt(row.id, 10),
+      quantity: parseInt(row.quantity, 10),
+      parent_id: row.parent_id ? parseInt(row.parent_id, 10) : null,
+    }));
   }
 
-  private async fetchAgeGroups(
-    applicationId: number,
-  ): Promise<AgeGroup[]> {
+  private async fetchAgeGroups(applicationId: number): Promise<any[]> {
     const { rows } = await this.db.query(
       `SELECT ag.*, aag.male, aag.female
        FROM bb_application_agegroup aag
@@ -208,9 +219,7 @@ export class ApplicationService {
     return rows;
   }
 
-  private async fetchTargetAudience(
-    applicationId: number,
-  ): Promise<number[]> {
+  private async fetchTargetAudience(applicationId: number): Promise<number[]> {
     const { rows } = await this.db.query(
       `SELECT ta.id
        FROM bb_application_targetaudience ata
@@ -222,9 +231,7 @@ export class ApplicationService {
     return rows.map((r) => r.id);
   }
 
-  private async fetchDocuments(
-    applicationId: number,
-  ): Promise<Document[]> {
+  private async fetchDocuments(applicationId: number): Promise<any[]> {
     const { rows } = await this.db.query(
       `SELECT * FROM bb_document_application
        WHERE owner_id = $1`,

--- a/src/WebSocket/node/src/modules/application/dto/application.dto.ts
+++ b/src/WebSocket/node/src/modules/application/dto/application.dto.ts
@@ -1,0 +1,159 @@
+import { Expose, Exclude, Type, Transform } from 'class-transformer';
+import { sanitizeString } from './transforms';
+import { DateDto } from './date.dto';
+import { ResourceShortDto } from './resource-short.dto';
+import { OrderDto } from './order.dto';
+import { DocumentDto } from './document.dto';
+
+/**
+ * Mirrors PHP: App\modules\bookingfrontend\models\Application
+ * Class default: @Exclude — only @Expose fields are serialized.
+ *
+ * Nested relations use @Type for class-transformer to apply their own DTOs:
+ * - dates: DateDto (PHP @SerializeAs array of Date)
+ * - resources: ResourceShortDto (PHP @SerializeAs array of Resource, short=true)
+ * - orders: OrderDto (PHP @SerializeAs array of Order)
+ * - documents: DocumentDto (PHP @SerializeAs array of Document)
+ * - articles: plain objects {id, quantity, parent_id} — no model in PHP
+ * - agegroups: raw rows — no model serialization in PHP
+ * - audience: number[] — no model serialization in PHP
+ */
+@Exclude()
+export class ApplicationDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  id_string: string;
+
+  @Expose()
+  active: number;
+
+  @Expose()
+  display_in_dashboard: number;
+
+  @Expose()
+  type: string;
+
+  @Expose()
+  status: string;
+
+  @Expose()
+  secret: string;
+
+  @Expose()
+  created: string;
+
+  @Expose()
+  modified: string;
+
+  @Expose()
+  @Transform(({ value }) => sanitizeString(value))
+  building_name: string;
+
+  @Expose()
+  building_id: number;
+
+  @Expose()
+  frontend_modified: string | null;
+
+  @Expose()
+  owner_id: number;
+
+  @Expose()
+  case_officer_id: number | null;
+
+  @Expose()
+  activity_id: number;
+
+  @Expose()
+  customer_identifier_type: string;
+
+  @Expose()
+  customer_ssn: string | null;
+
+  @Expose()
+  customer_organization_number: string | null;
+
+  @Expose()
+  @Transform(({ value }) => sanitizeString(value))
+  name: string;
+
+  @Expose()
+  organizer: string;
+
+  @Expose()
+  homepage: string | null;
+
+  @Expose()
+  description: string | null;
+
+  @Expose()
+  equipment: string | null;
+
+  @Expose()
+  contact_name: string;
+
+  @Expose()
+  contact_email: string;
+
+  @Expose()
+  contact_phone: string;
+
+  @Expose()
+  responsible_street: string;
+
+  @Expose()
+  responsible_zip_code: string;
+
+  @Expose()
+  responsible_city: string;
+
+  @Expose()
+  session_id: string | null;
+
+  @Expose()
+  agreement_requirements: string | null;
+
+  @Expose()
+  external_archive_key: string | null;
+
+  @Expose()
+  customer_organization_name: string | null;
+
+  @Expose()
+  customer_organization_id: number | null;
+
+  @Expose()
+  recurring_info: string | null;
+
+  // --- Relations ---
+
+  @Expose()
+  @Type(() => DateDto)
+  dates: DateDto[];
+
+  @Expose()
+  @Type(() => ResourceShortDto)
+  resources: ResourceShortDto[];
+
+  @Expose()
+  @Type(() => OrderDto)
+  orders: OrderDto[];
+
+  @Expose()
+  @Type(() => DocumentDto)
+  documents: DocumentDto[];
+
+  /** PHP returns raw agegroup rows — no model serialization */
+  @Expose()
+  agegroups: any[];
+
+  /** PHP returns number[] of target audience IDs */
+  @Expose()
+  audience: number[];
+
+  /** PHP ArticleRepository returns only {id, quantity, parent_id} */
+  @Expose()
+  articles: any[];
+}

--- a/src/WebSocket/node/src/modules/application/dto/date.dto.ts
+++ b/src/WebSocket/node/src/modules/application/dto/date.dto.ts
@@ -1,0 +1,21 @@
+import { Expose, Exclude, Transform } from 'class-transformer';
+import { formatOsloTimestamp } from './transforms';
+
+/**
+ * Mirrors PHP: App\modules\bookingfrontend\models\helper\Date
+ * Class default: @Exclude — only @Expose fields are serialized.
+ * PHP applies @Timestamp on from_ and to_ (ISO 8601, Europe/Oslo).
+ */
+@Exclude()
+export class DateDto {
+  @Expose()
+  @Transform(({ value }) => formatOsloTimestamp(value))
+  from_: string;
+
+  @Expose()
+  @Transform(({ value }) => formatOsloTimestamp(value))
+  to_: string;
+
+  @Expose()
+  id: number;
+}

--- a/src/WebSocket/node/src/modules/application/dto/document.dto.ts
+++ b/src/WebSocket/node/src/modules/application/dto/document.dto.ts
@@ -1,0 +1,53 @@
+import { Expose, Exclude, Transform } from 'class-transformer';
+
+/**
+ * Mirrors PHP: App\modules\bookingfrontend\models\Document
+ * Class default: @Exclude — only @Expose fields are serialized.
+ *
+ * PHP Document constructor parses metadata JSON and extracts focal_point_x/y.
+ * owner_type is explicitly @Exclude in PHP.
+ */
+@Exclude()
+export class DocumentDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  description: string;
+
+  @Expose()
+  category: string;
+
+  @Expose()
+  owner_id: number;
+
+  @Expose()
+  @Transform(({ value }) => {
+    if (typeof value === 'string') {
+      try { return JSON.parse(value); } catch { return null; }
+    }
+    return value ?? null;
+  })
+  metadata: any;
+
+  @Expose()
+  @Transform(({ obj }) => {
+    const meta = typeof obj.metadata === 'string'
+      ? (() => { try { return JSON.parse(obj.metadata); } catch { return null; } })()
+      : obj.metadata;
+    return meta?.focal_point?.x ?? null;
+  })
+  focal_point_x: number | null;
+
+  @Expose()
+  @Transform(({ obj }) => {
+    const meta = typeof obj.metadata === 'string'
+      ? (() => { try { return JSON.parse(obj.metadata); } catch { return null; } })()
+      : obj.metadata;
+    return meta?.focal_point?.y ?? null;
+  })
+  focal_point_y: number | null;
+}

--- a/src/WebSocket/node/src/modules/application/dto/index.ts
+++ b/src/WebSocket/node/src/modules/application/dto/index.ts
@@ -1,0 +1,7 @@
+export { ApplicationDto } from './application.dto';
+export { DateDto } from './date.dto';
+export { ResourceShortDto } from './resource-short.dto';
+export { OrderDto } from './order.dto';
+export { OrderLineDto } from './order-line.dto';
+export { DocumentDto } from './document.dto';
+export { formatOsloTimestamp, sanitizeString, parseBool } from './transforms';

--- a/src/WebSocket/node/src/modules/application/dto/order-line.dto.ts
+++ b/src/WebSocket/node/src/modules/application/dto/order-line.dto.ts
@@ -1,0 +1,49 @@
+import { Expose, Exclude, Transform } from 'class-transformer';
+import { sanitizeString } from './transforms';
+
+/**
+ * Mirrors PHP: App\modules\bookingfrontend\models\OrderLine
+ * Class default: @Exclude — only @Expose fields are serialized.
+ */
+@Exclude()
+export class OrderLineDto {
+  @Expose()
+  order_id: number;
+
+  @Expose()
+  status: number;
+
+  @Expose()
+  parent_mapping_id: number;
+
+  @Expose()
+  article_mapping_id: number;
+
+  @Expose()
+  quantity: number;
+
+  @Expose()
+  unit_price: number;
+
+  @Expose()
+  overridden_unit_price: number;
+
+  @Expose()
+  currency: string;
+
+  @Expose()
+  amount: number;
+
+  @Expose()
+  unit: string;
+
+  @Expose()
+  tax_code: number;
+
+  @Expose()
+  tax: number;
+
+  @Expose()
+  @Transform(({ value }) => sanitizeString(value))
+  name: string;
+}

--- a/src/WebSocket/node/src/modules/application/dto/order.dto.ts
+++ b/src/WebSocket/node/src/modules/application/dto/order.dto.ts
@@ -1,0 +1,23 @@
+import { Expose, Exclude, Type } from 'class-transformer';
+import { OrderLineDto } from './order-line.dto';
+
+/**
+ * Mirrors PHP: App\modules\bookingfrontend\models\Order
+ * Class default: @Exclude — only @Expose fields are serialized.
+ *
+ * PHP Order model uses:
+ *   @SerializeAs(type="array", of="App\modules\bookingfrontend\models\OrderLine")
+ * for the lines property.
+ */
+@Exclude()
+export class OrderDto {
+  @Expose()
+  order_id: number;
+
+  @Expose()
+  sum: number;
+
+  @Expose()
+  @Type(() => OrderLineDto)
+  lines: OrderLineDto[];
+}

--- a/src/WebSocket/node/src/modules/application/dto/resource-short.dto.ts
+++ b/src/WebSocket/node/src/modules/application/dto/resource-short.dto.ts
@@ -1,0 +1,64 @@
+import { Expose, Exclude, Transform } from 'class-transformer';
+import { sanitizeString, parseBool } from './transforms';
+
+/**
+ * Mirrors PHP: App\modules\bookingfrontend\models\Resource (short=true serialization)
+ * Class default: @Exclude — only @Expose + @Short fields are serialized.
+ *
+ * In the PHP Application model, resources use:
+ *   @SerializeAs(type="array", of="App\modules\bookingfrontend\models\Resource", short=true)
+ * So only properties with both @Expose and @Short are included.
+ *
+ * Note: PHP Resource.populate() always sets deactivate_calendar = 0.
+ */
+@Exclude()
+export class ResourceShortDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  @Transform(({ value }) => sanitizeString(value))
+  name: string;
+
+  @Expose()
+  activity_id: number | null;
+
+  @Expose()
+  active: number;
+
+  @Expose()
+  rescategory_id: number | null;
+
+  @Expose()
+  direct_booking: number | null;
+
+  @Expose()
+  simple_booking: number | null;
+
+  @Expose()
+  simple_booking_start_date: number | null;
+
+  @Expose()
+  participant_limit: number | null;
+
+  @Expose()
+  @Transform(() => false) // PHP populate() hardcodes this to 0
+  deactivate_calendar: boolean;
+
+  @Expose()
+  @Transform(({ value }) => parseBool(value))
+  deactivate_application: boolean;
+
+  @Expose()
+  @Transform(({ value }) => parseBool(value))
+  hidden_in_frontend: boolean;
+
+  @Expose()
+  activate_prepayment: number | null;
+
+  @Expose()
+  short_description: any;
+
+  @Expose()
+  building_id: number | null;
+}

--- a/src/WebSocket/node/src/modules/application/dto/transforms.ts
+++ b/src/WebSocket/node/src/modules/application/dto/transforms.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared transform helpers matching PHP SerializableTrait behavior.
+ */
+
+/**
+ * Format a timestamp to ISO 8601 in Europe/Oslo timezone.
+ * Matches PHP @Timestamp annotation defaults (format="c", sourceTimezone="Europe/Oslo").
+ */
+export function formatOsloTimestamp(value: any): string | null {
+  if (value == null) return null;
+  try {
+    const date = value instanceof Date ? value : new Date(value);
+    if (isNaN(date.getTime())) return String(value);
+
+    // Format date components in Oslo timezone
+    const formatted = date.toLocaleString('sv-SE', {
+      timeZone: 'Europe/Oslo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+
+    return formatted.replace(' ', 'T') + getOsloOffset(date);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Get the UTC offset string for Europe/Oslo at a given date (e.g., "+02:00").
+ */
+function getOsloOffset(date: Date): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Europe/Oslo',
+    timeZoneName: 'longOffset',
+  }).formatToParts(date);
+  const tzPart = parts.find((p) => p.type === 'timeZoneName');
+  if (tzPart) {
+    const match = tzPart.value.match(/GMT([+-]\d{2}:\d{2})/);
+    if (match) return match[1];
+  }
+  return '+01:00';
+}
+
+/**
+ * Decode HTML entities matching PHP @EscapeString(mode="default") / sanitizeString().
+ */
+export function sanitizeString(value: any): string | null {
+  if (value == null) return null;
+  if (typeof value !== 'string') return value;
+  let decoded = value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)));
+  // Handle double-encoded entities
+  if (decoded.includes('&amp;')) {
+    decoded = decoded.replace(/&amp;/g, '&');
+  }
+  return decoded;
+}
+
+/**
+ * Parse string booleans matching PHP @ParseBool behavior.
+ */
+export function parseBool(value: any): boolean {
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase().trim();
+    if (['true', 'yes', '1'].includes(lower)) return true;
+    return false;
+  }
+  if (typeof value === 'number') return value === 1;
+  if (value === null || value === undefined) return false;
+  return !!value;
+}


### PR DESCRIPTION
Use class-transformer DTOs (ApplicationDto, DateDto, ResourceShortDto, OrderDto, OrderLineDto, DocumentDto) to ensure the WebSocket partial_applications_response matches the PHP GET /partials endpoint output. Strips null values, formats dates in Oslo timezone, filters resource fields to @Short set, and matches PHP order grouping.